### PR TITLE
Start ReScript with -w if build.watch is set

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,12 +47,12 @@ export default function createReScriptPlugin(): Plugin {
   return {
     name: '@jihchi/vite-plugin-rescript',
     async configResolved(resolvedConfig) {
-      const { command, mode } = resolvedConfig;
+      const { build, command, mode } = resolvedConfig;
       const needReScript =
         (command === 'serve' && mode === 'development') || command === 'build';
 
       if (needReScript) {
-        await launchReScript(command === 'serve');
+        await launchReScript(command === 'serve' || Boolean(build.watch));
       }
     },
   };


### PR DESCRIPTION
Sometimes you'd like to just start the rollup watcher without the dev server with `vite build --watch`. This change makes it so that the ReScript compiler also starts in watch mode if build.watch is set to true (or a truthy value).