### PR TITLE
Allow any version of node after 16.

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,6 @@
   },
   "packageManager": "pnpm@8.7.6",
   "engines": {
-    "node": "^16 || ^18 || ^20"
+    "node": ">=16.0"
   }
 }


### PR DESCRIPTION
Node has recently released the version 21 (non LTS).  But this tool doesn't really run in production, but in the build pipelines and developer's machines where the Node version can vary widely, but also controlled (in CI build pipelines).

The only APIs which are used are fairly stable (path, and fs).  So we should allow the developer to upgrade their node version and still use this plugin to build their rescript projects with Vite.