### PR TITLE
Add `silent` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ export default defineConfig({
         output: './lib/js',
         suffix: '.mjs',
       },
+      silent: false,
     }),
   ],
 });


### PR DESCRIPTION
When deploying to some providers, the log may not work because of the log line limit. This option is expected to be used to avoid such situations.